### PR TITLE
Use interrupt to detect falling edge

### DIFF
--- a/01_hall_1.py
+++ b/01_hall_1.py
@@ -1,32 +1,24 @@
 #!/usr/bin/env python
 import RPi.GPIO as GPIO
 
-HallPin = 11    # pin11 --- hall
-LedPin  = 12    # pin12 --- led
+HALL = 11
 
-def setup():
-	GPIO.setmode(GPIO.BOARD)       # Numbers GPIOs by physical location
-	GPIO.setup(LedPin, GPIO.OUT)   # Set LedPin's mode is output
-	GPIO.setup(HallPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-	GPIO.output(LedPin, GPIO.HIGH) # Set LedPin high(+3.3V) to off led
+GPIO.setmode(GPIO.BOARD)
+GPIO.setwarnings(False)
+GPIO.setup(HALL,GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-def loop():
-	while True:
-		if GPIO.input(HallPin) == GPIO.LOW:
-			print '...led on'
-			GPIO.output(LedPin, GPIO.LOW)  # led on
-		else:
-			print 'led off...'
-			GPIO.output(LedPin, GPIO.HIGH) # led off
+def magnet_detected(channel):
+        print "Magnetic material detected"  
 
-def destroy():
-	GPIO.output(LedPin, GPIO.HIGH)     # led off
-	GPIO.cleanup()                     # Release resource
+GPIO.add_event_detect(HALL, GPIO.FALLING, callback=magnet_detected)
 
-if __name__ == '__main__':     # Program start from here
-	setup()
-	try:
-		loop()
-	except KeyboardInterrupt:  # When 'Ctrl+C' is pressed, the child program destroy() will be  executed.
-		destroy()
+try:
+    while True:
+        pass
+
+except KeyboardInterrupt:
+    print "Ctrl-C - quit"
+
+finally:
+    GPIO.cleanup() 
 


### PR DESCRIPTION
The original code is running in an endless loop and prints a message on each iteration. This is slow and consumes a lot of CPU. It's also not possible to run other code in parallel.

In this version, the gpio-event-detection is used to detect magnetic material. For this a listener is registered for falling-events. Once this is detected a message is printed to the console.

The LED-part is missing here as the sensor-module has an own LED that turns on once a magnetic material is detected.

Possible improvements:
- add bounce-time for debouncing 
- listen for BOTH events and print message that magnetic material was removed
