### PR TITLE
Use interrupts instead loop, fix HIGH-LOW-bug

### DIFF
--- a/08_reedSwitch.py
+++ b/08_reedSwitch.py
@@ -8,19 +8,23 @@ def setup():
 	GPIO.setmode(GPIO.BOARD)       # Numbers GPIOs by physical location
 	GPIO.setup(LedPin, GPIO.OUT)   # Set LedPin's mode is output
 	GPIO.setup(ReedPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-	GPIO.output(LedPin, GPIO.HIGH) # Set LedPin high(+3.3V) to off led
+	GPIO.output(LedPin, GPIO.LOW) # Set LedPin high(+3.3V) to off led
+
+def switchLed(channel):
+	if GPIO.input(11):
+		print "Magnet detected - LED on!"
+		GPIO.output(LedPin,GPIO.HIGH)
+	else:
+		print "No magnet detected - LED off!"
+		GPIO.output(LedPin,GPIO.LOW)
 
 def loop():
+	GPIO.add_event_detect(ReedPin,GPIO.BOTH, callback=switchLed, bouncetime=20)
 	while True:
-		if GPIO.input(ReedPin) == GPIO.LOW:
-			print '...led on'
-			GPIO.output(LedPin, GPIO.LOW)  # led on
-		else:
-			print 'led off...'
-			GPIO.output(LedPin, GPIO.HIGH) # led off
+        	pass
 
 def destroy():
-	GPIO.output(LedPin, GPIO.HIGH)     # led off
+	GPIO.output(LedPin, GPIO.LOW)     # led off
 	GPIO.cleanup()                     # Release resource
 
 if __name__ == '__main__':     # Program start from here
@@ -29,4 +33,5 @@ if __name__ == '__main__':     # Program start from here
 		loop()
 	except KeyboardInterrupt:  # When 'Ctrl+C' is pressed, the child program destroy() will be  executed.
 		destroy()
+
 


### PR DESCRIPTION
- Use of interrupt with GPIO.add_event_detect instead of constantly reading the input in a loop
- Fix mixed HIGH and LOW usage
